### PR TITLE
Fix extension definition

### DIFF
--- a/xExtension-Teem/extension.php
+++ b/xExtension-Teem/extension.php
@@ -16,6 +16,16 @@ class TeemExtension extends Minz_Extension
      */
     protected $showContent = false;
 
+    public function install()
+    {
+        return true;
+    }
+
+    public function uninstall()
+    {
+        return true;
+    }
+
     /**
      * Initialize this extension
      */


### PR DESCRIPTION
Before, extension was missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extension have all mandatory method definitions.